### PR TITLE
Optimize images

### DIFF
--- a/overlay-blue.svg
+++ b/overlay-blue.svg
@@ -1,8 +1,1 @@
-<?xml version="1.0" ?>
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 1 1" preserveAspectRatio="none">
-  <linearGradient id="grad-ucgg-generated" gradientUnits="userSpaceOnUse" x1="0%" y1="50%" x2="100%" y2="39%">
-    <stop offset="0%" stop-color="#cdeaff" stop-opacity=".77"/>
-    <stop offset="100%" stop-color="#ffffff" stop-opacity=".77"/>
-  </linearGradient>
-  <rect x="0" y="0" width="1" height="1" fill="url(#grad-ucgg-generated)" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1" preserveAspectRatio="none"><linearGradient id="a" gradientUnits="userSpaceOnUse" x1="0%" y1="50%" y2="39%"><stop offset="0%" stop-color="#cdeaff" stop-opacity=".77"/><stop offset="100%" stop-color="#fff" stop-opacity=".77"/></linearGradient><path fill="url(#a)" d="M0 0h1v1H0z"/></svg>

--- a/ruby.svg
+++ b/ruby.svg
@@ -1,12 +1,1 @@
-<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'>
-<path d='M20,100l74-5l6-75zM61,35l37-2l-29-24z' fill='#b11' fill-rule='evenodd'/>
-<path d='M21,100l74-5l-47-4zM98,33c4-12,5-29-14-33l-15,9l29,24z' fill='#811' fill-rule='evenodd'/>
-<path d='M7,67l14,33l11-38z' fill='#d44' fill-rule='evenodd'/>
-<path d='M29,61l42,13l-10-42zM56,0h28l-16,10zM1,51l-1,29l7-13z' fill='#c22' fill-rule='evenodd'/>
-<path d='M32,61l39,13c-14,13-30,24-50,26z' fill='#a00' fill-rule='evenodd'/>
-<path d='M61,35l10,39l17-23zM32,61l16,30c9-5,16-11,23-17l-39-13z' fill='#900' fill-rule='evenodd'/>
-<path d='M61,35l27,17l10-20l-37,3z' fill='#800' fill-rule='evenodd'/>
-<path d='M71,74l23,21l-6-44zM0,80c1,19,15,20,21,20l-14-33l-7,13zM7,67l-2,26c4,6,9,7,15,6c-4-11-13-32-13-32zM69,9l30,4c-1-7-6-11-15-13l-15,9z' fill='#911' fill-rule='evenodd'/>
-<path d='M1,51l6,16l25-5l29-27l8-26l-13-9l-22,8c-6,7-20,19-20,19c-1,1-9,16-13,24z' fill='#ebb' fill-rule='evenodd'/>
-<path d='M21,21c15-14,34-23,42-16c7,8-1,26-16,40c-14,15-33,24-41,17c-7-7,1-26,15-41z' fill='#b11' fill-rule='evenodd'/>
-</svg>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="M20 100l74-5 6-75zm41-65l37-2L69 9z" fill="#b11" fill-rule="evenodd"/><path d="M21 100l74-5-47-4zm77-67c4-12 5-29-14-33L69 9l29 24z" fill="#811" fill-rule="evenodd"/><path d="M7 67l14 33 11-38z" fill="#d44" fill-rule="evenodd"/><path d="M29 61l42 13-10-42zM56 0h28L68 10zM1 51L0 80l7-13z" fill="#c22" fill-rule="evenodd"/><path d="M32 61l39 13c-14 13-30 24-50 26z" fill="#a00" fill-rule="evenodd"/><path d="M61 35l10 39 17-23zM32 61l16 30c9-5 16-11 23-17L32 61z" fill="#900" fill-rule="evenodd"/><path d="M61 35l27 17 10-20-37 3z" fill="#800" fill-rule="evenodd"/><path d="M71 74l23 21-6-44zM0 80c1 19 15 20 21 20L7 67 0 80zm7-13L5 93c4 6 9 7 15 6C16 88 7 67 7 67zM69 9l30 4C98 6 93 2 84 0L69 9z" fill="#911" fill-rule="evenodd"/><path d="M1 51l6 16 25-5 29-27 8-26-13-9-22 8c-6 7-20 19-20 19-1 1-9 16-13 24z" fill="#ebb" fill-rule="evenodd"/><path d="M21 21C36 7 55-2 63 5c7 8-1 26-16 40C33 60 14 69 6 62c-7-7 1-26 15-41z" fill="#b11" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
## Inchworm Image Optimization Summary

Inchworm optimized 2 images for a total savings of 176 B (11.3%).

| Image | Original | Optimized | Savings | % |
| :-- | --: | --: | --: | --: |
| ruby.svg | 1.05 KB | 1.01 KB | 38 B | 3.5% |
| overlay-blue.svg | 481 B | 343 B | 138 B | 28.7% |
